### PR TITLE
feat: add ints.h to minizip Makefile.am include_HEADERS

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+zlib (1:1.3.dfsg+really1.3.2-1deepin2) unstable; urgency=medium
+
+  * Add ints.h to minizip Makefile.am include_HEADERS.
+
+ -- lichenggang <lichenggang@uniontech.com>  Thu, 23 Apr 2026 16:45:32 +0800
+
 zlib (1:1.3.dfsg+really1.3.2-1deepin1) unstable; urgency=medium
 
   * Revert 64-bit time_t changes.

--- a/debian/patches/add-ints.h-to-minizip-makefile-am.patch
+++ b/debian/patches/add-ints.h-to-minizip-makefile-am.patch
@@ -1,0 +1,21 @@
+From: Rui Chen <rui@chenrui.dev>
+Date: Tue, 17 Feb 2026 10:48:39 -0500
+Subject: Add dependency to ints.h in minizip Makefile.am.
+
+So that ints.h is part of the installation.
+Upstream: https://github.com/madler/zlib/commit/cb14dc9ade3759352417a300e6c2ed73268f1d97
+---
+ contrib/minizip/Makefile.am | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/contrib/minizip/Makefile.am b/contrib/minizip/Makefile.am
+--- a/contrib/minizip/Makefile.am
++++ b/contrib/minizip/Makefile.am
+@@ -27,6 +27,7 @@ libminizip_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:0:0 -lz
+ minizip_includedir = $(includedir)/minizip
+ minizip_include_HEADERS = \
+ 	crypt.h \
++	ints.h \
+ 	ioapi.h \
+ 	mztools.h \
+ 	unzip.h \

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+add-ints.h-to-minizip-makefile-am.patch


### PR DESCRIPTION
## Summary

Upstream fix: [madler/zlib@cb14dc9](https://github.com/madler/zlib/commit/cb14dc9ade3759352417a300e6c2ed73268f1d97)

The `ints.h` header was introduced in zlib 1.3.2 but was not included in the `minizip_include_HEADERS` list in `contrib/minizip/Makefile.am`. This caused `ints.h` to not be installed during `make install`, breaking builds of packages that include minizip headers (e.g., wireshark) which depend on `ints.h` via `ioapi.h`.

## Fix

- Add `ints.h` to `minizip_include_HEADERS` in `contrib/minizip/Makefile.am`

## Impact

- Fixes wireshark and other packages failing to build with `fatal error: ints.h: No such file or directory`